### PR TITLE
Fix PrimeNet DayMemory error

### DIFF
--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -1914,7 +1914,7 @@ def setup(config, options):
 		config.set(SEC.PrimeNet, "CpuSpeed", str(freq))
 		options.memory = memory
 		config.set(SEC.PrimeNet, "memory", str(memory))
-		options.day_night_memory = memory * 0.9
+		options.day_night_memory = int(memory * 0.9)
 	if tf1g:
 		options.min_exp = MAX_PRIMENET_EXP
 		config.set(SEC.PrimeNet, "GetMinExponent", str(MAX_PRIMENET_EXP))


### PR DESCRIPTION
I tried to configure version 1.1 to work with `mfaktc` by running the `--setup` prompt, but encountered this error:

```
ERROR: PrimeNet error 7: Invalid parameter
ERROR: parameter DayMemory: Invalid int value/precision char '22118.4'
```

Apparently, version 1.1 writes the `Memory` value to `prime.ini` as a floating-pointer number: 

```
Memory = 22118.4
```

While the version 1.0.2 writes it as an integer:
```
Memory = 22118
```

This pull request adds an explicit conversion of this value to an integer, which fixes this error on my system.
