### PR TITLE
Reserve whole range when getting TF assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vscode/launch.json
+autoprimenet.py
+autoprimenet.log
+prime.ini
+worktodo.txt

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Options:
                         PrimeNet or TF1G
   --max-bit=MAX_BIT     Maximum bit level of TF assignments to get from
                         PrimeNet or TF1G
+  --max-bit-enforce     Uses --max-bit parameter as the "Factor To" bit 
+                        level for TF assignements effectively reserving the
+                        whole range.
   -m, --mlucas          Get assignments for Mlucas.
   -g, --gpuowl          Get assignments for GpuOwl.
   --prpll               Get assignments for PRPLL. PRPLL is not PrimeNet

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Options:
                         PrimeNet or TF1G
   --max-bit-enforce     Uses --max-bit parameter as the "Factor To" bit 
                         level for TF assignements effectively reserving the
-                        whole range.
+                        entire range.
   -m, --mlucas          Get assignments for Mlucas.
   -g, --gpuowl          Get assignments for GpuOwl.
   --prpll               Get assignments for PRPLL. PRPLL is not PrimeNet

--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -4917,7 +4917,9 @@ def get_assignment(
 			config.remove_option(SEC.PrimeNet, "ProofHashLength")
 	elif assignment.work_type == PRIMENET.WORK_TYPE_FACTOR:
 		assignment.sieve_depth = float(r["sf"])
-		assignment.factor_to = float(r["ef"])
+		if options.max_bit_enforce : 
+			assignment.factor_to = options.max_bit 
+		else: assignment.factor_to = float(r["ef"])
 	elif assignment.work_type == PRIMENET.WORK_TYPE_PFACTOR:
 		assignment.k = float(r["A"])
 		assignment.b = int(r["b"])
@@ -6799,6 +6801,13 @@ parser.add_option("--max-exp", dest="max_exp", type="int", help="Maximum exponen
 
 parser.add_option("--min-bit", dest="min_bit", type="int", help="Minimum bit level of TF assignments to get from PrimeNet or TF1G")
 parser.add_option("--max-bit", dest="max_bit", type="int", help="Maximum bit level of TF assignments to get from PrimeNet or TF1G")
+
+parser.add_option(
+	"--max-bit-enforce", 
+	dest="max_bit_enforce", 
+	action="store_true",
+	help="Override TF assignments to end at the bit level specified for --max-bit."
+)
 
 parser.add_option("-m", "--mlucas", action="store_true", help="Get assignments for Mlucas.")
 parser.add_option("-g", "--gpuowl", action="store_true", help="Get assignments for GpuOwl.")

--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -6804,7 +6804,6 @@ parser.add_option("--max-bit", dest="max_bit", type="int", help="Maximum bit lev
 
 parser.add_option(
 	"--max-bit-enforce", 
-	dest="max_bit_enforce", 
 	action="store_true",
 	help="Override TF assignments to end at the bit level specified for --max-bit."
 )


### PR DESCRIPTION
I wanted a way to reserve an entire range when getting TF assignments. Current functionality seems to be getting one TF bit level at a time. 
My use case is to fully TF exponents to recommended levels on one machine and do the PRP on another. I intend to use this in conjunction with the --max-bit parameter.  For example; `automprimnet.py --min-exp=404000000 --max-exp=404050000 --max-bit=81 --max-bit-enforce`
This would record the TF assignment for the exponent 404040401 as  404040401,77,81 as it has currently been factored to 77 and I specified 81 as --max-bit

This pull request is a very basic one. I'm happy to use this PR as the basis of discussion around how/if this feature should be implemented and less about its actual code viability.
