### PR TITLE
Restore compatibility with mfaktc v0.24-alpha.1

### DIFF
--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -4502,7 +4502,9 @@ def tf_ghd_credit(exp, bit_min, bit_max):
 
 
 # "%s%u %d %d %d %s: %d %d %s %llu %08X", NAME_NUMBERS, exp, bit_min, bit_max, NUM_CLASSES, MFAKTC_VERSION, cur_class, num_factors, strlen(factors_string) ? factors_string : "0", bit_level_time, i
-MFAKTC_TF_RE = re.compile(br'^M(\d+) (\d+) (\d+) (\d+) ([^\s:]+): (\d+) (\d+) (0|"\d+"(?:,"\d+")*|\d+(?:,\d+)*) (\d+) ([\dA-F]{8})$')
+MFAKTC_TF_RE = re.compile(
+	br'^M(\d+) (\d+) (\d+) (\d+) ([^\s:]+): (\d+) (\d+) (0|"\d+"(?:,"\d+")*|\d+(?:,\d+)*) (\d+) ([\dA-F]{8})$'
+)
 
 
 def parse_work_unit_mfaktc(adapter, filename, p):
@@ -4852,10 +4854,9 @@ def parse_prpll_log_file(adapter, adir, p):
 
 def get_mfaktc_output_filename(adir, p, sieve_depth, factor_to):
 	"""Get the mfaktc output filename based on the assignment and mfaktc version."""
-	filenames = glob.glob("M{0}_{1}-{2}_*.ckp".format(p, int(sieve_depth), int(factor_to)))
-	for filename in filenames:
-		if (os.path.isfile(os.path.join(adir, filename))):
-			return filename
+	filenames = glob.glob(os.path.join(adir, "M{0}_{1}-{2}_[0-9]*.ckp".format(p, int(sieve_depth), int(factor_to))))
+	if filenames:
+		return os.path.basename(filenames[0])
 	# default to <= 0.23 mfaktc filenames if new one not found
 	return "M{0}.ckp".format(p)
 

--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -4849,11 +4849,25 @@ def parse_prpll_log_file(adapter, adir, p):
 
 	return iteration, avg_msec_per_iter, stage, pct_complete, fftlen, bits, buffs
 
+
 MFAKTC_NUM_CLASSES = 4620
+
+
+def get_mfaktc_output_filename(adir, p, sieve_depth, factor_to):
+	"""Get the mfaktc output filename based on the assignment and mfaktc version."""
+	new_filename = "M{0}_{1}-{2}_{3}.ckp".format(p, int(sieve_depth), int(factor_to), MFAKTC_NUM_CLASSES) # used with mfaktc 0.24.0
+	old_filename = "M{0}.ckp".format(p) # used with mfaktc <= 0.23
+
+	# if the file with the new filename structure exists, use it
+	if (os.path.isfile(os.path.join(adir, new_filename))):
+		return new_filename
+	# otherwise, assume the old filename structure	
+	return old_filename
+
 
 def parse_mfaktc_output_file(adapter, adir, p, sieve_depth, factor_to):
 	"""Parse the mfaktc output file for the progress of the assignment."""
-	savefile = os.path.join(adir, "M{0}_{1}-{2}_{3}.ckp".format(p, int(sieve_depth), int(factor_to), MFAKTC_NUM_CLASSES))
+	savefile = os.path.join(adir, get_mfaktc_output_filename(adir, p, sieve_depth, factor_to))
 	iteration = 0
 	avg_msec_per_iter = None
 	stage = pct_complete = None
@@ -7753,7 +7767,7 @@ def update_progress_all(adapter, adir, cpu_num, last_time, tasks, checkin=True):
 	modified = True
 	file = os.path.join(
 		adir,
-		"M{0}_{1}-{2}_{3}.ckp".format(p, int(assignment.sieve_depth), int(assignment.factor_to), MFAKTC_NUM_CLASSES)
+		get_mfaktc_output_filename(adir, p, assignment.sieve_depth, assignment.factor_to)
 		if options.mfaktc
 		else "M{0}.ckp".format(p)
 		if options.mfakto

--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -4849,10 +4849,11 @@ def parse_prpll_log_file(adapter, adir, p):
 
 	return iteration, avg_msec_per_iter, stage, pct_complete, fftlen, bits, buffs
 
+MFAKTC_NUM_CLASSES = 4620
 
-def parse_mfaktc_output_file(adapter, adir, p):
+def parse_mfaktc_output_file(adapter, adir, p, sieve_depth, factor_to):
 	"""Parse the mfaktc output file for the progress of the assignment."""
-	savefile = os.path.join(adir, "M{0}.ckp".format(p))
+	savefile = os.path.join(adir, "M{0}_{1}-{2}_{3}.ckp".format(p, int(sieve_depth), int(factor_to), MFAKTC_NUM_CLASSES))
 	iteration = 0
 	avg_msec_per_iter = None
 	stage = pct_complete = None
@@ -4893,7 +4894,7 @@ def get_progress_assignment(adapter, adir, assignment):
 	elif options.cudalucas:  # CUDALucas
 		result = parse_cuda_output_file(adapter, adir, assignment.n)
 	elif options.mfaktc:  # mfaktc
-		result = parse_mfaktc_output_file(adapter, adir, assignment.n)
+		result = parse_mfaktc_output_file(adapter, adir, assignment.n, assignment.sieve_depth, assignment.factor_to)
 	elif options.mfakto:  # mfakto
 		result = parse_mfakto_output_file(adapter, adir, assignment.n)
 	else:  # Mlucas
@@ -7752,8 +7753,10 @@ def update_progress_all(adapter, adir, cpu_num, last_time, tasks, checkin=True):
 	modified = True
 	file = os.path.join(
 		adir,
-		"M{0}.ckp".format(p)
-		if options.mfaktc or options.mfakto
+		"M{0}_{1}-{2}_{3}.ckp".format(p, int(assignment.sieve_depth), int(assignment.factor_to), MFAKTC_NUM_CLASSES)
+		if options.mfaktc
+		else "M{0}.ckp".format(p)
+		if options.mfakto
 		else "c{0}".format(p)
 		if options.cudalucas
 		else "gpuowl.log"

--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -4502,7 +4502,7 @@ def tf_ghd_credit(exp, bit_min, bit_max):
 
 
 # "%s%u %d %d %d %s: %d %d %s %llu %08X", NAME_NUMBERS, exp, bit_min, bit_max, NUM_CLASSES, MFAKTC_VERSION, cur_class, num_factors, strlen(factors_string) ? factors_string : "0", bit_level_time, i
-MFAKTC_TF_RE = re.compile(br'^M(\d+) (\d+) (\d+) (\d+) ([^\s:]+): (\d+) (\d+) (0|"\d+"(?:,"\d+")*) (\d+) ([\dA-F]{8})$')
+MFAKTC_TF_RE = re.compile(br'^M(\d+) (\d+) (\d+) (\d+) ([^\s:]+): (\d+) (\d+) (0|"\d+"(?:,"\d+")*|\d+(?:,\d+)*) (\d+) ([\dA-F]{8})$')
 
 
 def parse_work_unit_mfaktc(adapter, filename, p):
@@ -4850,19 +4850,14 @@ def parse_prpll_log_file(adapter, adir, p):
 	return iteration, avg_msec_per_iter, stage, pct_complete, fftlen, bits, buffs
 
 
-MFAKTC_NUM_CLASSES = 4620
-
-
 def get_mfaktc_output_filename(adir, p, sieve_depth, factor_to):
 	"""Get the mfaktc output filename based on the assignment and mfaktc version."""
-	new_filename = "M{0}_{1}-{2}_{3}.ckp".format(p, int(sieve_depth), int(factor_to), MFAKTC_NUM_CLASSES) # used with mfaktc 0.24.0
-	old_filename = "M{0}.ckp".format(p) # used with mfaktc <= 0.23
-
-	# if the file with the new filename structure exists, use it
-	if (os.path.isfile(os.path.join(adir, new_filename))):
-		return new_filename
-	# otherwise, assume the old filename structure	
-	return old_filename
+	filenames = glob.glob("M{0}_{1}-{2}_*.ckp".format(p, int(sieve_depth), int(factor_to)))
+	for filename in filenames:
+		if (os.path.isfile(os.path.join(adir, filename))):
+			return filename
+	# default to <= 0.23 mfaktc filenames if new one not found
+	return "M{0}.ckp".format(p)
 
 
 def parse_mfaktc_output_file(adapter, adir, p, sieve_depth, factor_to):

--- a/gimps_status.py
+++ b/gimps_status.py
@@ -256,7 +256,9 @@ TF_v2_RE = re.compile(br"^OWL TF (2) (\d+) (\d+) (\d+) (\d+) (\d+)$")
 # mfaktc/mfakto headers
 
 # "%s%u %d %d %d %s: %d %d %s %llu %08X", NAME_NUMBERS, exp, bit_min, bit_max, NUM_CLASSES, MFAKTC_VERSION, cur_class, num_factors, strlen(factors_string) ? factors_string : "0", bit_level_time, i
-MFAKTC_TF_RE = re.compile(br'^([MW])(\d+) (\d+) (\d+) (\d+) ([^\s:]+): (\d+) (\d+) (?:(0|"\d+"(?:,"\d+")*) (\d+) )?([\dA-F]{8})$')
+MFAKTC_TF_RE = re.compile(
+	br'^([MW])(\d+) (\d+) (\d+) (\d+) ([^\s:]+): (\d+) (\d+) (?:(0|"\d+"(?:,"\d+")*|\d+(?:,\d+)*) (\d+) )?([\dA-F]{8})$'
+)
 
 # "%u %d %d %d %s: %d %d %s %llu %08X\n", exp, bit_min, bit_max, mystuff.num_classes, MFAKTO_VERSION, cur_class, num_factors, strlen(factors_string) ? factors_string : "0", bit_level_time, i
 MFAKTO_TF_RE = re.compile(br'^(\d+) (\d+) (\d+) (\d+) (mfakto [^\s:]+): (\d+) (\d+) (?:(0|"\d+"(?:,"\d+")*) (\d+) )?([\dA-F]{8})$')
@@ -284,7 +286,7 @@ GPUOWL_RE = re.compile(
 	+ r"(?:([0-9]+)(?:-([0-9]+)\.(?:ll|prp|p1final|p2)|(?:-[0-9]+-([0-9]+))?\.p1|(-old)?\.(?:(?:ll|p[12])\.)?owl)|unverified\.prp(\.bak)?)|[0-9]+(-prev)?\.(?:tf\.)?owl)$"
 )
 PRPLL_RE = re.compile(r"(?:(?:ll-)?([0-9]+)" + re.escape(os.sep) + r"(?:([0-9]+)-([0-9]+)\.(?:ll|prp)|unverified\.prp))$")
-MFAKTC_RE = re.compile(r"^([MW][0-9]+)\.ckp$")
+MFAKTC_RE = re.compile(r"^([MW][0-9]+)(?:_[0-9]+-[0-9]+_[0-9]+)?\.ckp$")
 MFAKTO_RE = re.compile(r"^(M[0-9]+)\.ckp(\.bu)?$")
 
 


### PR DESCRIPTION
mfaktc v0.24-alpha.1 changes the format of the name of the checkpoint file:

```
-  sprintf(filename, "%s%u.ckp", NAME_NUMBERS, exp);
+  sprintf(filename, "%s%u_%d-%d_%d.ckp", NAME_NUMBERS, exp, bit_min, bit_max, NUM_CLASSES);
```

This pull request adds support of this new checkpoint filename format.
(Though there might be better ways to implement it..)