### PR TITLE
Mark file into regions

### DIFF
--- a/autoprimenet.py
+++ b/autoprimenet.py
@@ -2052,7 +2052,7 @@ def email_autoconfig(email):
 
 # endregion
 # region Remote (PrimeNet and TF1G)
-def setup(config, options):
+def setup(config, args):
 	"""Configures the GIMPS/PrimeNet client with user preferences and system settings."""
 	wrapper = textwrap.TextWrapper(width=75)
 	print(


### PR DESCRIPTION
A few text editors support marking a file into foldable regions. This #region ... #endregion syntax is from VS and VS code, but Vim can be configured to support it as well.

These regions are a band-aid on what should probably be multiple files. The file is logically grouped well-enough that folding is useful, though, kudos. If splitting happens they will happen along these markers.

Using the Region Helper extension, one gets an outline like this:

<img width="728" height="599" alt="image" src="https://github.com/user-attachments/assets/acf491cc-8215-49f3-bd16-f74a13fa355d" />
<img width="771" height="474" alt="image" src="https://github.com/user-attachments/assets/23150acc-1995-4f6f-a2da-a5fa1fc3a1b4" />

which I think is reasonably navigable.